### PR TITLE
Fix #2: Allow applyTransform to return a promise

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 
 # `slate-drop-or-paste-images`
 
-A Slate plugin that inserts images on drop or paste. 
+A Slate plugin that inserts images on drop or paste.
 
 When trying to add support for inserting images, there are many ways that a user can do it. In total, this plugin enables six ways of inserting images. The user can choose between:
 
@@ -48,6 +48,7 @@ const plugins = [
 
 #### Arguments
 - `applyTransform: Function` — a transforming function that is passed a Slate `Transform` and a `File` object representing an image. It should apply the proper transform that inserts the image into Slate based on your schema.
+  It can return a promise resolved with the resulting Slate `Transform`.
 - `[extensions: Array]` — an array of allowed extensions.
 
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "data-uri-to-blob": "0.0.4",
+    "es6-promise": "^4.0.5",
     "image-to-data-uri": "^1.0.0",
     "is-data-uri": "^0.1.0",
     "is-image": "^1.0.1",


### PR DESCRIPTION
This PR fixes #2, it allows `applyTransform` to returns a promise resolved with a Slate `Transform`.

I agree that doing async operations in an `onPaste` is not perfect, but since `onInsertText` and `onInsertHtml` are async, it only impacts `onInsertFiles`.
