### PR TITLE
Make applyTransform more flexible

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ const plugins = [
 ```
 
 #### Arguments
-- `applyTransform: Function` — a transforming function that is passed a Slate `Transform` and a `File` object representing an image. It should apply the proper transform that inserts the image into Slate based on your schema.
+- `applyTransform: Function` — a transforming function that is passed a Slate `Transform`, a `File` object representing an image, and the `Editor` instance. It should apply the proper transform that inserts the image into Slate based on your schema.
   It can return a promise resolved with the resulting Slate `Transform`.
 - `[extensions: Array]` — an array of allowed extensions.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,9 +34,9 @@ function DropOrPasteImages({
 
   function asyncApplyTransform(transform, editor, file) {
     return Promise
-      .resolve(applyTransform(transform, file))
-      .then(() => {
-        const next = transform.apply()
+      .resolve(applyTransform(transform, editor, file))
+      .then(tr => {
+        const next = tr.apply()
         editor.onChange(next)
       })
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,9 +34,9 @@ function DropOrPasteImages({
 
   function asyncApplyTransform(transform, editor, file) {
     return Promise
-      .resolve(applyTransform(transform, editor, file))
-      .then(tr => {
-        const next = tr.apply()
+      .resolve(applyTransform(transform, file, editor))
+      .then(response => {
+        const next = (response || transform).apply()
         editor.onChange(next)
       })
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "example": "browserify ./example/index.js --debug --transform babelify > ./example/build.js",
     "gh-pages": "npm run dist && npm run example && gh-pages --dist ./example",
     "lint": "eslint 'lib/**/*.js' 'example/index.js'",
+    "prepare": "npm run dist",
     "prepublish": "npm run dist",
     "start": "http-server ./example -p 8888",
     "test": "npm run lint",


### PR DESCRIPTION
Two small improvements that make the `applyTransform` callback more flexible. For my usecase this allows me to update the state of the document multiple times while a file is uploading, for example to display a placeholder or upload progress.

- Pass the editor instance as an additional argument. It's a shame that the order is different to the internal implementation however obviously best for backwards compat.
- If a transform object is returned from the promise then use that, as documented.