### PR TITLE
Fix broken example

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -42,7 +42,7 @@ class Example extends React.Component {
 
   plugins = [
     InsertImages({
-      applyTransform: (transform, file) => {
+      insertImage: (transform, file) => {
         return transform.insertBlock({
           type: 'image',
           isVoid: true,


### PR DESCRIPTION
Renamed `applyTransform` to `insertImage` per deprecation notice. Note: I didn't actually run this locally to test, just threw together the PR in GitHub's UI.